### PR TITLE
Add antora directory hierarchy.

### DIFF
--- a/.github/workflows/guide-website-update.yml
+++ b/.github/workflows/guide-website-update.yml
@@ -1,0 +1,37 @@
+name: Guide Web Site Deploy
+
+on:
+  push:
+    branches: master
+    paths:
+      - 'doc/**'
+
+jobs:
+  antora:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2.3.1
+        with:
+          repository: hazelcast-guides/guides-site
+          ref: master
+          token: ${{ secrets.SECRET_TOKEN }}
+
+      - name: Install Antora
+        run: |
+          sudo apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates
+          curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+          sudo apt -y install nodejs
+          sudo npm i -g @antora/cli@2.3 @antora/site-generator-default@2.3
+      - name: Build website artifacts
+        run: |
+          antora --clean --fetch --to-dir ./docs antora-playbook.yml
+          touch docs/.nojekyll
+      - name: Commit artifacts changes
+        run: |
+          git config --global user.name 'devOpsHazelcast'
+          git config --global user.email 'devops@hazelcast.com'
+          export GUIDE_REPO=$(cut -d/ -f2 <<<"${GITHUB_REPOSITORY}")
+          export COMMIT_ID=$(git rev-parse --short "$GITHUB_SHA")
+          git commit -am "${GUIDE_REPO}-${COMMIT_ID} guide update"
+      - name: Push artifacts to guides-site repo
+        run: git push

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+See the guide [here](include published URL).

--- a/create.sh
+++ b/create.sh
@@ -1,2 +1,2 @@
-asciidoctor -a allow-uri-read *.adoc;
-asciidoctor-pdf -a allow-uri-read *.adoc;
+asciidoctor -D . -a allow-uri-read doc/modules/ROOT/pages/*.adoc;
+asciidoctor-pdf -D . -a allow-uri-read doc/modules/ROOT/pages/*.adoc;

--- a/doc/antora.yml
+++ b/doc/antora.yml
@@ -1,2 +1,3 @@
 name: guide-name    # a brief module name. This will be included in the guide url.
 title: Guide Title  # a brief module title. This will not show up on the website.
+version: v1.0-beta

--- a/doc/antora.yml
+++ b/doc/antora.yml
@@ -1,0 +1,2 @@
+name: guide-name    # a brief module name. This will be included in the guide url.
+title: Guide Title  # a brief module title. This will not show up on the website.

--- a/doc/antora.yml
+++ b/doc/antora.yml
@@ -1,3 +1,4 @@
 name: guide-name    # a brief module name. This will be included in the guide url.
 title: Guide Title  # a brief module title. This will not show up on the website.
-version: v1.0-beta
+version: master
+

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -5,7 +5,11 @@ You can clone this repository, work on it and create your guide, and then push t
 ////
 
 :github-address: [github-repo-address-of-your-guide]
+
 :templates-url: https://raw.githubusercontent.com/hazelcast-guides/adoc-templates/master
+
+// Use this relative url if you are going to publish the guide on the guides site.
+// :templates-url: templates:ROOT:page$/
 
 = Title
 

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -40,3 +40,7 @@ Write the steps in your guide here by making each step a different section
 == See Also
 
 // Add some links to resources, such as other related guides.
+// Use relative links used on the home page (see https://raw.githubusercontent.com/hazelcast-guides/guides-site/master/home/modules/ROOT/pages/index.adoc)
+
+- xref:hazelcast-embedded-springboot:ROOT:index.adoc[Hazelcast in SpringBoot]
+- xref:hazelcast-quarkus:ROOT:index.adoc[Hazelcast Client for Quarkus] 

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -9,6 +9,10 @@ You can clone this repository, work on it and create your guide, and then push t
 :templates-url: https://raw.githubusercontent.com/hazelcast-guides/adoc-templates/master
 
 // Use this relative url if you are going to publish the guide on the guides site.
+// Note that this url will not work locally and raise asciidoctor errors.
+// So, complete the guide with the above url and set the below one just before 
+// publishing on the guides site.
+//
 // :templates-url: templates:ROOT:page$/
 
 = Title


### PR DESCRIPTION
To be able to include a guide in the [site](https://github.com/hazelcast-guides/guides-site), it has to have a certain file hierarchy for antora files. This PR creates a template for the files and required directories to have a common structure across guides.

(Wikipage also needs to be updated accordingly.)